### PR TITLE
fix：修复jsonSerialize返回定义和接口JsonSerializable类要求不一致的问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "laravel"
   ],
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=8.0",
     "qiniu/php-sdk": "^7.2",
     "league/flysystem": "^3.23"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8d71e94d86230eac7ea8618762d6c53",
+    "content-hash": "6101f4b5269df82abc1b68182342ba9d",
     "packages": [
         {
             "name": "league/flysystem",
@@ -954,16 +954,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "9.6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
                 "shasum": ""
             },
             "require": {
@@ -1037,7 +1037,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
             },
             "funding": [
                 {
@@ -1053,7 +1053,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2024-01-19T07:03:14+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2076,7 +2076,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/src/QiniuUrl.php
+++ b/src/QiniuUrl.php
@@ -107,7 +107,7 @@ class QiniuUrl implements JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    function jsonSerialize()
+    function jsonSerialize() : mixed
     {
         return $this->__toString();
     }


### PR DESCRIPTION
Return type of Jefferyjob\QiniuStorage\QiniuUrl::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /www/vendor/jefferyjob/qiniu-laravel-storage/src/QiniuUrl.php on line 110

参考链接：https://www.php.net/manual/zh/jsonserializable.jsonserialize.php


这个错误是PHP的返回类型声明错误，提示`Jefferyjob\QiniuStorage\QiniuUrl`类的`jsonSerialize`方法的返回类型应该要么与`JsonSerializable::jsonSerialize()`的返回类型兼容（mixed），要么使用`#[\ReturnTypeWillChange]`属性来临时抑制这个错误提示。

在PHP中，如果一个类实现了`JsonSerializable`接口，那么它的`jsonSerialize`方法应该返回`mixed`类型。然而，根据错误信息，似乎`Jefferyjob\QiniuStorage\QiniuUrl`类的`jsonSerialize`方法返回类型与`JsonSerializable::jsonSerialize()`的返回类型不兼容，因此需要进行调整。

你可以通过以下两种方式解决这个问题：

1. **调整返回类型为mixed**：
   确保`QiniuUrl`类的`jsonSerialize`方法的返回类型为`mixed`，这样就与`JsonSerializable::jsonSerialize()`接口定义兼容了。修改方法的声明如下：
   ```php
   public function jsonSerialize(): mixed {
       // 方法实现
   }
   ```

2. **使用#[\ReturnTypeWillChange]属性**：
   如果你正在升级PHP版本，而且修改返回类型可能引发其他问题，你可以使用`#[\ReturnTypeWillChange]`属性来抑制这个错误提示。这是一个临时的解决方案，因为在未来的PHP版本中，你仍然需要调整返回类型以符合接口的定义。在方法前添加这个属性，如下所示：
   ```php
   #[\ReturnTypeWillChange]
   public function jsonSerialize() {
       // 方法实现
   }
   ```

请注意，第二种方法只是为了在升级PHP版本时提供一个临时解决方案，最好的做法是根据实际情况调整`jsonSerialize`方法的返回类型以符合接口定义。